### PR TITLE
Update link to iRODS-demo

### DIFF
--- a/07_iCommands_Handson_User-Training.md
+++ b/07_iCommands_Handson_User-Training.md
@@ -39,7 +39,7 @@ Use the temporary vsc-account and the password that you received at the start of
 
 ### Configuration of the iRODS connection
 
-Connect to the KU Leuven iRODS portal (https://irods-demo.t.icts.kuleuven.be) and follow the instructions of the section iRODS Linux Client
+Connect to the KU Leuven iRODS portal (https://demo.irods.t.icts.kuleuven.be) and follow the instructions of the section iRODS Linux Client
 
 You will be then start an iRODS session that will last 7 days. 
 


### PR DESCRIPTION
I updated the link in iCommands. There is a small place (the slide of login portal) in module three which also needs to be changed.
https://github.com/hpcleuven/iRODS-local-admin-training/blob/development/03_KULeuven-testbed-infrastructuur.pdf
We will change it later.